### PR TITLE
Change names in feature code too

### DIFF
--- a/Suffixer.roboFontExt/lib/suffixer.py
+++ b/Suffixer.roboFontExt/lib/suffixer.py
@@ -71,7 +71,7 @@ class Suffixer:
 		self.w = FloatingWindow((300, 200), "Suffixer")
 		p = 10
 		h = 20
-		y1, y2, y3, y4 = 15, 49, 82, 135, 169
+		y1, y2, y3, y4, y5 = 15, 49, 82, 135, 169
 		w1, x2 = 160, 180
 		
 		self.w.labelTwo = TextBox((p, y1, w1, h), "Add suffix to glyph names:")

--- a/Suffixer.roboFontExt/lib/suffixer.py
+++ b/Suffixer.roboFontExt/lib/suffixer.py
@@ -214,7 +214,11 @@ class Suffixer:
 			return
 
 		fea_path = os.path.join(font.path, 'features.fea')
-		fea_ast = Parser(fea_path,font.glyphOrder).parse()
+		try: # fail more gracefully when files mentioned in includes are not found
+			fea_ast = Parser(fea_path,font.glyphOrder).parse()
+		except Exception as e:
+			print(e)
+			return
 
 		### these next 2 blocks slightly alter extisting behavior
 		### within feaLib to change glyph names when calling asFea

--- a/Suffixer.roboFontExt/lib/suffixer.py
+++ b/Suffixer.roboFontExt/lib/suffixer.py
@@ -59,8 +59,8 @@ class Suffixer:
 		currentSuffix = ""
 		if CurrentGlyph() is not None:
 			currentSuffix = self._findSuffix(CurrentGlyph().name)
-		elif self.f.selection is not None:
-			for gn in self.f.selection:
+		elif self.f.selectedGlyphNames is not None:
+			for gn in self.f.selectedGlyphNames:
 				currentSuffix = self._findSuffix(gn)
 				if currentSuffix != None:
 					break

--- a/Suffixer.roboFontExt/lib/suffixer.py
+++ b/Suffixer.roboFontExt/lib/suffixer.py
@@ -107,8 +107,11 @@ class Suffixer:
 		if self.w.replace.get() == False:
 			self.w.scope.set(0)
 			self.w.scope.enable(0)
+			self.w.inFeatureCode.set(0)
+			self.w.inFeatureCode.enable(0)
 		else:
 			self.w.scope.enable(1)
+			self.w.inFeatureCode.enable(1)
 		
 	
 	def _findSuffix(self, gname):

--- a/Suffixer.roboFontExt/lib/suffixer.py
+++ b/Suffixer.roboFontExt/lib/suffixer.py
@@ -139,6 +139,8 @@ class Suffixer:
 		else:
 			scope = self.f.keys() if self.w.scope.get() == 1 else self.f.selectedGlyphNames
 
+			renameDict = dict() # collect all name changes in one dict
+
 			if mode == "replace":
 				for gname in scope:
 					if gname.endswith(suffixes[0]):
@@ -148,13 +150,16 @@ class Suffixer:
 						else:
 							sufLenWithPeriod = sufLen+1
 							newName = gname[:-sufLenWithPeriod]
-						self._changeGlyphname(gname, newName)
+						renameDict[gname] = newName
 							
 			elif mode == "append":
 				for gname in scope:
 					newName = gname + "." + suffixes[1]
-					self._changeGlyphname(gname, newName)
-					
+					renameDict[gname] = newName
+
+			for oldName, newName in renameDict.items():
+				self._changeGlyphname(oldName, newName)
+
 			self.f.changed()
 			
 			# store new values as defaults

--- a/Suffixer.roboFontExt/lib/suffixer.py
+++ b/Suffixer.roboFontExt/lib/suffixer.py
@@ -65,10 +65,10 @@ class Suffixer:
 				if currentSuffix != None:
 					break
 		
-		self.w = FloatingWindow((300, 166), "Suffixer")
+		self.w = FloatingWindow((300, 200), "Suffixer")
 		p = 10
 		h = 20
-		y1, y2, y3, y4 = 15, 49, 82, 135
+		y1, y2, y3, y4 = 15, 49, 82, 135, 169
 		w1, x2 = 160, 180
 		
 		self.w.labelTwo = TextBox((p, y1, w1, h), "Add suffix to glyph names:")
@@ -85,11 +85,15 @@ class Suffixer:
 		self.w.scope = RadioGroup((p, y3, -p, h*2), ["Target selected glyphs", "Replace all in current font"], isVertical=True)
 		self.w.scope.set(0)
 
+		self.w.inFeatureCode = CheckBox((p+2, y4, -p, h), "Change glyph names in feature code")
+		self.w.inFeatureCode.set(0)
+
 		currentState = 0 if currentSuffix == "" or currentSuffix == None else 1
 		self.w.replace.set(currentState)
 		self.w.scope.enable(currentState)
+		self.w.inFeatureCode.enable(currentState)
 			
-		self.w.submit = Button((p, y4, -p, h), "Change suffixes", callback=self.replaceSuffixes)
+		self.w.submit = Button((p, y5, -p, h), "Change suffixes", callback=self.replaceSuffixes)
 		self.w.setDefaultButton(self.w.submit)
 		self.w.open()
 		self.w.makeKey()


### PR DESCRIPTION
This add a new checkbox that makes it possible for the user to decide if the suffix changes should also be applied to the font’s feature code. 

Granted this might not be the most useful thing when renaming `ss02` to `ss03`, but in situations where you decide (or are required) to change your numerator suffix or your file has pre-generated kerning info within your feature file this might come in handy.